### PR TITLE
Fix artist image consistency and fallback logic

### DIFF
--- a/packages/core/src/plugins/meta/audius.ts
+++ b/packages/core/src/plugins/meta/audius.ts
@@ -94,7 +94,7 @@ class AudiusMetaProvider extends MetaProvider {
       onTour: hasLastFmArtist ? lastFmInfo.ontour === '1' : false,
       coverImage,
       thumb,
-      images: [],
+      images: [coverImage, thumb],
       topTracks: _.map(ArtistTracks, (track) => ({
         name: track.title,
         title: track.title,


### PR DESCRIPTION
## Description  
This PR addresses an inconsistency in the artist image display between the search results and the individual artist view. Previously, the artist's picture was visible in the search results but not on the artist's dedicated page. The solution implements a fallback mechanism to reuse the background image when only one image is available.

## Changes Made  
- Implemented a fallback mechanism to ensure the artist image is displayed on the artist's page when only one image is available.
- Updated the rendering logic to check for the availability of multiple images.

## Screenshots  
**Original Search Results (with thumbnail displayed):**  
![Original Search Result 1](https://github.com/user-attachments/assets/3ae0c2b6-1bda-411b-993f-f832b41b15fc)  
![Original Search Result 2](https://github.com/user-attachments/assets/3ec82897-8195-42e0-84b3-e0d39854056c)  

**After Modifications (Search Page):**  
![Modified Search Page](https://github.com/user-attachments/assets/bde4426c-36ca-4f36-8639-cada4d0789ef)  

**Artist Page (After Modifications):**  
![Artist Page](https://github.com/user-attachments/assets/ff78a6f9-5e2e-488e-b140-09ab8e40ab00)  
