### PR TITLE
[Feature] Auto-Download Favorite Tracks (#1091)

### DIFF
--- a/packages/app/app/actions/downloads.ts
+++ b/packages/app/app/actions/downloads.ts
@@ -47,6 +47,7 @@ export const addToDownloads = createStandardAction(DownloadActionTypes.ADD_TO_DO
       };
     
       downloads = [...downloads, newDownload];
+      store.set('downloads', downloads);
 
       return {
         payload: { downloads, track: clonedTrack.uuid }

--- a/packages/app/app/actions/favorites.ts
+++ b/packages/app/app/actions/favorites.ts
@@ -42,8 +42,6 @@ export function addFavoriteTrack(track) {
     const streamProviders: StreamProviderPlugin[] = store.get('StreamProvider') || [];
     
     addToDownloads(streamProviders, track);
-  } else {
-    console.log('Auto-download is disabled, skipping download');
   }
   
   return {

--- a/packages/app/app/actions/favorites.ts
+++ b/packages/app/app/actions/favorites.ts
@@ -4,6 +4,8 @@ import { areTracksEqualByName, getTrackItem } from '@nuclear/ui';
 
 import { safeAddUuid } from './helpers';
 import { createStandardAction } from 'typesafe-actions';
+import { addToDownloads } from './downloads';
+import StreamProviderPlugin from '@nuclear/core/src/plugins/streamProvider';
 
 export const READ_FAVORITES = 'READ_FAVORITES';
 export const ADD_FAVORITE_TRACK = 'ADD_FAVORITE_TRACK';
@@ -32,6 +34,17 @@ export function addFavoriteTrack(track) {
   favorites.tracks = [...filteredTracks, omit(clonedTrack, 'streams')];
   
   store.set('favorites', favorites);
+
+  const settings = store.get('settings');
+  const autoDownloadFavourites = settings.autoDownloadFavourites;
+  
+  if (autoDownloadFavourites) {
+    const streamProviders: StreamProviderPlugin[] = store.get('StreamProvider') || [];
+    
+    addToDownloads(streamProviders, track);
+  } else {
+    console.log('Auto-download is disabled, skipping download');
+  }
   
   return {
     type: ADD_FAVORITE_TRACK,

--- a/packages/app/app/containers/SettingsContainer/__snapshots__/SettingsContainer.test.tsx.snap
+++ b/packages/app/app/containers/SettingsContainer/__snapshots__/SettingsContainer.test.tsx.snap
@@ -1613,6 +1613,34 @@ exports[`Settings view container should render settings 1`] = `
               />
             </div>
           </div>
+          <div
+            class="settings_item boolean"
+          >
+            <span
+              class="settings_item_text"
+            >
+              <label
+                class="settings_item_name"
+              >
+                auto-download-favourites
+              </label>
+            </span>
+            <div
+              class="spacer"
+            />
+            <div
+              class="ui fitted toggle checkbox"
+            >
+              <input
+                class="hidden"
+                readonly=""
+                tabindex="0"
+                type="radio"
+                value=""
+              />
+              <label />
+            </div>
+          </div>
         </div>
       </div>
       <div

--- a/packages/app/app/containers/SettingsContainer/__snapshots__/SettingsContainer.test.tsx.snap
+++ b/packages/app/app/containers/SettingsContainer/__snapshots__/SettingsContainer.test.tsx.snap
@@ -1622,7 +1622,7 @@ exports[`Settings view container should render settings 1`] = `
               <label
                 class="settings_item_name"
               >
-                auto-download-favourites
+                Auto download favorite track
               </label>
             </span>
             <div

--- a/packages/core/src/settings/index.ts
+++ b/packages/core/src/settings/index.ts
@@ -300,6 +300,13 @@ export const settingsConfig: Array<Setting> = [
     min: 1
   },
   {
+    name: 'autoDownloadFavourites',
+    category: 'downloads',
+    type: SettingType.BOOLEAN,
+    prettyName: 'auto-download-favourites',
+    default: false
+  },
+  {
     name: 'devtools',
     category: 'developer',
     type: SettingType.BOOLEAN,

--- a/packages/i18n/src/locales/ar_SA.json
+++ b/packages/i18n/src/locales/ar_SA.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "جنون المذياع التلقائي",
     "autoradio-craziness-description": "سيختار المذياع التلقائي الأغاني التي لا تشبه الأغاني الموجودة فعلًا في قائمة الانتظار كلما كانت أكثر جنونًا",
     "autoradio-description": "إضافة اغنية مشابهة تلقائياً عند انتهاء قائمة الانتظار",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "تاريخ الاستماع",
     "listening-history-description": "سجل المسارات التي تستمع إليها، لا Last.fm. يتم تخزين السجل دون اتصال.",
     "compact-menu-bar": "استخدام النمط المدمج لشريط القائمة",

--- a/packages/i18n/src/locales/be_BY.json
+++ b/packages/i18n/src/locales/be_BY.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Вар'яцкае Аўтарадыё",
     "autoradio-craziness-description": "Аўтарадыё абярэ песні, якія менш падобныя на тыя, што ўжо ёсць у чарзе, тым больш шалёна гэта будзе",
     "autoradio-description": "Дадаваць падобныя трэкі аўтаматычна, калі чарга заканчваецца",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Гісторыя праслухоўвання",
     "listening-history-description": "Рэгіструйце трэкі, якія вы слухаеце, напрыклад Last.fm. Гісторыя захоўваецца ў аўтаномным рэжыме.",
     "compact-menu-bar": "Выкарыстоўваць кампактны стыль для радкоў меню",

--- a/packages/i18n/src/locales/bn_BD.json
+++ b/packages/i18n/src/locales/bn_BD.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "অটোরেডিওর পাগলামি",
     "autoradio-craziness-description": "অটোরেডিও সেসব গান সিলেক্ট করবে যেগুলো ইতমধ্যে সারিতে থাকা গানের সাথে পার্থক্যপূর্ণ।",
     "autoradio-description": "সারি শেষ হয়ে গেলে স্বয়ংক্রিয়ভাবে সামঞ্জস্যপূর্ণ ট্র্যাক যুক্ত কর",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Listening history",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "কম্প্যাক্ট স্টাইল ব্যবহার করুন মেনু বারের জন্য",

--- a/packages/i18n/src/locales/cs.json
+++ b/packages/i18n/src/locales/cs.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Bláznivost autorádia",
     "autoradio-craziness-description": "Čím bláznivější, tím spíše autorádio vybere skladby, které se méně podobají těm, které jsou již ve frontě",
     "autoradio-description": "Přidat automaticky podobné skladby po dokončení přehrávání fronty",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Historie přehrávání",
     "listening-history-description": "Zaznamenávejte skladby, které posloucháte, a la Last.fm. Historie je ukládána offline.",
     "compact-menu-bar": "Použít kompaktní styl pro lištu menu",

--- a/packages/i18n/src/locales/de.json
+++ b/packages/i18n/src/locales/de.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradio-Verrücktheit",
     "autoradio-craziness-description": "Autoradio wählt Lieder, aus die anders sind, als die Lieder, die bereits in der Warteschlange sind",
     "autoradio-description": "Fügt ähnliche Lieder automatisch hinzu, falls die Warteschlange beendet wird",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Hörgeschichte",
     "listening-history-description": "Protokollieren Sie die Titel, die Sie bei Last.fm hören. Der Verlauf wird offline gespeichert.",
     "compact-menu-bar": "Kompakten Stil für Menüleiste verwenden",

--- a/packages/i18n/src/locales/dk.json
+++ b/packages/i18n/src/locales/dk.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradio vanvittighed",
     "autoradio-craziness-description": "Autoradio vælger sange som er mindre som de sange der allerede er i køen jo mere skør den er.",
     "autoradio-description": "Tilføj automatisk lignende sange når køen slutter.",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Listening history",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "Benyt kompakt stil til menu",

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -290,6 +290,7 @@
     "autoradio-craziness": "Autoradio craziness",
     "autoradio-craziness-description": "Autoradio will select songs that are less similar to the ones already in the queue the crazier it is",
     "autoradio-description": "Add similar tracks automatically when the queue is ending",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Listening history",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "Use compact style for menu bar",

--- a/packages/i18n/src/locales/es.json
+++ b/packages/i18n/src/locales/es.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Nivel de locura de Autoradio",
     "autoradio-craziness-description": "Autoradio seleccionará canciones diferentes a aquellas en la cola mientras más loco esté",
     "autoradio-description": "Añadir pistas similares automáticamente cuando la cola esté terminando",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Historial de reproducción",
     "listening-history-description": "Registre las canciones que escucha, a la Last.fm. El historial se almacena sin conexión.",
     "compact-menu-bar": "Usar el estilo compacto para la barra de menú",

--- a/packages/i18n/src/locales/fa_IR.json
+++ b/packages/i18n/src/locales/fa_IR.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradio craziness",
     "autoradio-craziness-description": "Autoradio will select songs that are less similar to the ones already in the queue the crazier it is",
     "autoradio-description": "Add similar tracks automatically when the queue is ending",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Listening history",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "Use compact style for menu bar",

--- a/packages/i18n/src/locales/fi.json
+++ b/packages/i18n/src/locales/fi.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradio hulluus",
     "autoradio-craziness-description": "Autoradio valitsee kappaleet jotka ovat vähemmän samanlaisia kuin ne jotka on jo jonossa",
     "autoradio-description": "Lisää samankaltaisia kappaleita automaattisesti kun jono on loppumassa",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Kuunteluhistoria",
     "listening-history-description": "Ylöskirjaa raidat joita kuuntelet, tyyliin Last.fm. Historiasi taltioidaan yhteydettömässä tilassa.",
     "compact-menu-bar": "Käytä kompaktia valikon palkkia",

--- a/packages/i18n/src/locales/fr.json
+++ b/packages/i18n/src/locales/fr.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Niveau de folie de l'autoradio",
     "autoradio-craziness-description": "Plus le niveau de folie de l'autoradio est élevé, moins les morceaux choisis seront cohérent avec ceux déjà présent dans la file d'attente",
     "autoradio-description": "Ajouter automatiquement des morceaux similaires lorsque la file d'attente se termine",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Historique d'écoute",
     "listening-history-description": "Enregistrez les pistes que vous écoutez, un Last.fm. L'historique est stocké hors ligne.",
     "compact-menu-bar": "Utiliser le style compacte pour la barre de menu",

--- a/packages/i18n/src/locales/gr.json
+++ b/packages/i18n/src/locales/gr.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Τρέλα του ράδιο αυτοκινήτου",
     "autoradio-craziness-description": "Αυξάνοντας το επίπεδο διαφοροποίησης, μειώνετε την ομοιότητα των τραγουδιών με αυτά της ουράς αναπαραγωγής",
     "autoradio-description": "Προσθέστε παρόμοια τραγούδια μόλις η τρέχουσα λίστα αναπαραγωγής φτάσει στο τέλος της",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Listening history",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "Χρησιμοποιήστε το συμπαγές μενού",

--- a/packages/i18n/src/locales/he_IL.json
+++ b/packages/i18n/src/locales/he_IL.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "טרוף רדיו אוטומטי",
     "autoradio-craziness-description": "הרדיו האוטומטי יבחר שירים שפחות דומים לאלו שכבר נמצאים בתור ככל שזה מטורף יותר",
     "autoradio-description": "הוסף רצועות דומות באופן אוטומטי כאשר התור מסתיים",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "היסטוריית האזנה",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "שימוש בסגנון חסכוני לסרגל התפריט",

--- a/packages/i18n/src/locales/hi_IN.json
+++ b/packages/i18n/src/locales/hi_IN.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "ऑटोरेडियो पागलपन",
     "autoradio-craziness-description": "ऑटोरेडियो उन गानों का चयन करेगा जो पहले से कतार में लगे गानों से कम मिलते-जुलते हैं",
     "autoradio-description": "कतार समाप्त होने पर स्वचालित रूप से समान ट्रैक जोड़ें",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Listening history",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "मेनू बार के लिए कॉम्पैक्ट शैली का प्रयोग करें",

--- a/packages/i18n/src/locales/hr.json
+++ b/packages/i18n/src/locales/hr.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradio ludilo",
     "autoradio-craziness-description": "Autoradio će odabrati pjesme koje su manje slične onima koje su već u redu čekanja što je luđe",
     "autoradio-description": "Automatski dodaj slične pjesme kad se red čekanja završava",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Povijest slušanja",
     "listening-history-description": "Zabilježite pjesme koje slušate na Last.fm-u. Povijest se pohranjuje na vašem uređaju.",
     "compact-menu-bar": "Koristi kompaktni stil za traku izbornika",

--- a/packages/i18n/src/locales/hu_HU.json
+++ b/packages/i18n/src/locales/hu_HU.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autómata rádió őrültsége",
     "autoradio-craziness-description": "Az autómata rádió olyan zenéket fog kiválasztani, amlyek annál kevésbé hasonlítanak az várólistán levőkre, ammenyivel őrültebb",
     "autoradio-description": "Hasonló számok autómatikus hozzáadása, amikor a várólista a végéhez ér",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Hallgatási előzmények",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "Use compact style for menu bar",

--- a/packages/i18n/src/locales/id.json
+++ b/packages/i18n/src/locales/id.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradio craziness",
     "autoradio-craziness-description": "Autoradio akan memilih lagu yang kurang mirip dengan yang sudah masuk ke daftar antrian",
     "autoradio-description": "Tambahkan lagu yang mirip secara otomatis di akhir daftar antrian",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Riwayat mendengarkan",
     "listening-history-description": "Log trek yang anda dengarkan ke, Last.fm. Riwayat akan disimpan secara luring.",
     "compact-menu-bar": "Gunakan gaya ringkas untuk papan menu",

--- a/packages/i18n/src/locales/is.json
+++ b/packages/i18n/src/locales/is.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Brjálæði sjálfvirkt útvarps",
     "autoradio-craziness-description": "Sjálfvirka útvarpið velur lög sem eru minna lík en þau sem eru núþegar í biðröð því brjálaðar verður það",
     "autoradio-description": "Sjálfkrafa bætir við svipuðum lögum þegar biðröð er að ljúka",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Listening history",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "Nota þéttan stíl fyrir aðalrimil",

--- a/packages/i18n/src/locales/it.json
+++ b/packages/i18n/src/locales/it.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Livello di follia della radio automatica",
     "autoradio-craziness-description": "La radio automatica, più folle è, più selezionerà canzoni meno simili a quelle già nella coda",
     "autoradio-description": "Aggiungere automaticamente tracce simili quando la coda termina",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Cronologia di ascolto",
     "listening-history-description": "Tieni traccia dei brani ascoltati, come avviene su Last.fm. La cronologia viene memorizzata offline.",
     "compact-menu-bar": "Usa lo stile compatto per la barra dei menù",

--- a/packages/i18n/src/locales/ja_JP.json
+++ b/packages/i18n/src/locales/ja_JP.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "ラジオのヤバさ",
     "autoradio-craziness-description": "ラジオがヤバいほど既に再生キューにある曲と似ていない曲を選びます",
     "autoradio-description": "キューにある曲と似たような曲を自動的にキューに追加します",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "再生履歴",
     "listening-history-description": "Last.fm 風に、聴いた曲を記録。この履歴はオフラインで保存されます。",
     "compact-menu-bar": "メニューバーを小型に表示",

--- a/packages/i18n/src/locales/ko.json
+++ b/packages/i18n/src/locales/ko.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "무작위 자동 재생",
     "autoradio-craziness-description": "얼마나 재생 목록과 비슷하지 않은 음악을 재생할지 조절할 수 있습니다.",
     "autoradio-description": "재생 목록이 끝나면 자동으로 비슷한 음악 연속 재생",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "재생 기록",
     "listening-history-description": "예를 들어 Last.fm 처럼 당신이 재생한 트랙을 기록합니다. 기록은 오프라인으로 저장됩니다.",
     "compact-menu-bar": "축소된 메뉴 바 사용",

--- a/packages/i18n/src/locales/ku_KMR.json
+++ b/packages/i18n/src/locales/ku_KMR.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Dînbûna Autoradio",
     "autoradio-craziness-description": "Autoradio wê stranên ku kêmtir mîna yên ku di rêza de ne hilbijêre",
     "autoradio-description": "Dema ku rêz diqede, stranên bi vî rengî bixweber tevlî bike",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Dîroka Guhdarkirinê",
     "listening-history-description": "Stranên ku tu guhdar dikî tomar bike bo Last.fm. dîrok derhêl tê tomarkirin.",
     "compact-menu-bar": "Ji bo darika kulînê şêwaza pêkhatî bi kar bîne",

--- a/packages/i18n/src/locales/lt_LT.json
+++ b/packages/i18n/src/locales/lt_LT.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradio linksmumas",
     "autoradio-craziness-description": "Autoradijas pasirinks dainas kurios yra ne panašios į dainas kurios yra eilėje",
     "autoradio-description": "Pridėti panašias dainas automatiškai kai eilė baigiasi",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Istorija",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "Naudoti kompaktinį meniu stilių",

--- a/packages/i18n/src/locales/lv_LV.json
+++ b/packages/i18n/src/locales/lv_LV.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradio trakums",
     "autoradio-craziness-description": "Autoradio atlasīs dziesmas, kas ir mazāk līdzīgas tām, kas jau atrodas rindā, jo trakāka tā būs",
     "autoradio-description": "Automātiski pievienot līdzīgus ierakstus, kad rinda beidzas",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Listening history",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "Izmantojiet kompakto stilu izvēlņu joslai",

--- a/packages/i18n/src/locales/nl.json
+++ b/packages/i18n/src/locales/nl.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Automatische radio - gekte",
     "autoradio-craziness-description": "Autoradio wil nummers selecteren die minder lijken op die welke al in de wachtrij staan hoe gekker het is",
     "autoradio-description": "Voeg soortgelijke nummers automatisch toe wanneer de wachtrij eindigt",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Luister geschiedenis",
     "listening-history-description": "Log de tracks waarnaar u luistert op Last.fm. De geschiedenis wordt offline opgeslagen.",
     "compact-menu-bar": "Compacte menubalk",

--- a/packages/i18n/src/locales/no_NO.json
+++ b/packages/i18n/src/locales/no_NO.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradio galskap",
     "autoradio-craziness-description": "Autoradio vil velge sanger som er mindre likt de som allerede er i køen den er det",
     "autoradio-description": "Legg til lignende spor automatisk ved avslutning av køen",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Listening history",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "Bruk kompakt stil for menylinje",

--- a/packages/i18n/src/locales/pl.json
+++ b/packages/i18n/src/locales/pl.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradio - tryb szaleństwa",
     "autoradio-craziness-description": "Autoradio będzie wybierać tym mniej podobne utwory do tych z kolejki odtwarzania, im większe wybrano szaleństwo",
     "autoradio-description": "Dodaj automatycznie podobne utwory, kiedy kolejka odtwarzania się kończy",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Historia odtwarzania",
     "listening-history-description": "Zapisuj utwory, których słuchasz, à la Last.fm. Historia jest przechowywana offline.",
     "compact-menu-bar": "Włącz uproszczony pasek menu",

--- a/packages/i18n/src/locales/pt_BR.json
+++ b/packages/i18n/src/locales/pt_BR.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradio Louco",
     "autoradio-craziness-description": "Quanto mais loucura, mais diferentes serão as sugestões automáticas em comparação a fila",
     "autoradio-description": "Adiciona faixas similares automaticamente quando a fila estiver acabando",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Histórico de músicas ouvidas",
     "listening-history-description": "Salve as faixas que você escutou, à la Last.fm. O histórico é armazenado localmente.",
     "compact-menu-bar": "Use estilo compacto para barra de menu",

--- a/packages/i18n/src/locales/ro_RO.json
+++ b/packages/i18n/src/locales/ro_RO.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradio craziness",
     "autoradio-craziness-description": "Autoradio will select songs that are less similar to the ones already in the queue the crazier it is",
     "autoradio-description": "Add similar tracks automatically when the queue is ending",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Listening history",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "Use compact style for menu bar",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Разброс автоподборки",
     "autoradio-craziness-description": "Чем выше уровень разброса, тем менее похожие дорожки будет предлагать автоподборка",
     "autoradio-description": "Автоматически добавлять похожие дорожки по завершении очереди",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "История прослушивания",
     "listening-history-description": "Журналировать дорожки, которые вы слушаете, наподобие Last.fm. История хранится в локально.",
     "compact-menu-bar": "Компактное меню",

--- a/packages/i18n/src/locales/se.json
+++ b/packages/i18n/src/locales/se.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradiogalenskap",
     "autoradio-craziness-description": "Autoradion kommer välja spår som skiljer sig från de som redan är tillagda i kön, ju mer ju galnare",
     "autoradio-description": "Lägg till liknande spår automatiskt när kön är färdigspelad",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Listening history",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "Använd en kompakt stil för menyfältet",

--- a/packages/i18n/src/locales/sk.json
+++ b/packages/i18n/src/locales/sk.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autorádiové šialenstvo",
     "autoradio-craziness-description": "Autorádio zvolí skladby, ktoré sú menej podobné skladbám, ktoré už v poradí sú",
     "autoradio-description": "Pridať podobné skladby automaticky, keď sa poradie končí",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Listening history",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "Stlačíť miesto pre menu",

--- a/packages/i18n/src/locales/sq.json
+++ b/packages/i18n/src/locales/sq.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradio craziness",
     "autoradio-craziness-description": "Autoradio do përzgjedhë këngë të cilat janë më pak të ngjashme me ato që janë aktualisht në radhë dhe më të çmenduara",
     "autoradio-description": "Shto këngë të ngjashme automatikisht kur radha është në përfundim",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Listening history",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "Përdor stilin kompakt për shiritin e menusë",

--- a/packages/i18n/src/locales/ta_IN.json
+++ b/packages/i18n/src/locales/ta_IN.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradio craziness",
     "autoradio-craziness-description": "Autoradio will select songs that are less similar to the ones already in the queue the crazier it is",
     "autoradio-description": "Add similar tracks automatically when the queue is ending",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Listening history",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "Use compact style for menu bar",

--- a/packages/i18n/src/locales/tk_TM.json
+++ b/packages/i18n/src/locales/tk_TM.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradio craziness",
     "autoradio-craziness-description": "Autoradio will select songs that are less similar to the ones already in the queue the crazier it is",
     "autoradio-description": "Add similar tracks automatically when the queue is ending",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Listening history",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "Use compact style for menu bar",

--- a/packages/i18n/src/locales/tl.json
+++ b/packages/i18n/src/locales/tl.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Kabaliwan ng Autoradio",
     "autoradio-craziness-description": "Ang Autoradio ay mamimili ng mga kanta na lalong kakaiba sa mga kanta na nasa pila",
     "autoradio-description": "Kusang magdagdag ng katulad na kanta pag paubos na ang nasa pila",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Listening history",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "Gamitin ang compact style para sa menu bar",

--- a/packages/i18n/src/locales/tr.json
+++ b/packages/i18n/src/locales/tr.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradio Çılgınlığı",
     "autoradio-craziness-description": "Autoradio çılgınlaştıkça kuyruktaki şarkılara daha az benzeyen şarkıları seçer",
     "autoradio-description": "Eğer kuyruk bitiyorsa otomatik olarak benzer şarkılar ekle",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Dinleme Geçmişi",
     "listening-history-description": "Dinlediğin parçaları la Last.fm e kaydet. Geçmiş çevrimdışı kaydedilir.",
     "compact-menu-bar": "Menü için kompakt stili kullan",

--- a/packages/i18n/src/locales/uk_UA.json
+++ b/packages/i18n/src/locales/uk_UA.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Авторадіо — божевілля",
     "autoradio-craziness-description": "Авторадіо вибере пісні, менш подібні до вже наявних у черзі",
     "autoradio-description": "Додавати подібні доріжки автоматично, коли черга досягає кінця",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Раніше прослухані",
     "listening-history-description": "Запам'ятовувати прослухані доріжки, наподобу Last.fm. Перелік прослуханих доріжок зберігається офлайн.",
     "compact-menu-bar": "Стиснути панель меню",

--- a/packages/i18n/src/locales/vi.json
+++ b/packages/i18n/src/locales/vi.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradio craziness",
     "autoradio-craziness-description": "Autoradio sẽ chọn các bài khác không tương tự với các bài hát trong danh sách đang phát",
     "autoradio-description": "Tự động thêm các bài hát tương tự khi danh sách phát kết thúc",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Mới phát gần đây",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "Sử dụng thanh menu dạng nhỏ",

--- a/packages/i18n/src/locales/yue_CN.json
+++ b/packages/i18n/src/locales/yue_CN.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradio craziness",
     "autoradio-craziness-description": "Autoradio will select songs that are less similar to the ones already in the queue the crazier it is",
     "autoradio-description": "Add similar tracks automatically when the queue is ending",
+    "auto-download-favourites": "Auto download favorite track",
     "listening-history": "Listening history",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "Use compact style for menu bar",

--- a/packages/i18n/src/locales/zh.json
+++ b/packages/i18n/src/locales/zh.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "变化",
     "autoradio-craziness-description": "得到",
     "autoradio-description": "似是而非",
+    "auto-download-favourites": "自动下载喜爱的曲目",
     "listening-history": "Listening history",
     "listening-history-description": "Log the tracks you listen to, a la Last.fm. The history is stored offline.",
     "compact-menu-bar": "大道至简",

--- a/packages/i18n/src/locales/zh_CN.json
+++ b/packages/i18n/src/locales/zh_CN.json
@@ -238,6 +238,7 @@
     "autoradio-craziness": "变化",
     "autoradio-craziness-description": "得到",
     "autoradio-description": "似是而非",
+    "auto-download-favourites": "自动下载喜爱的曲目",
     "compact-menu-bar": "大道至简",
     "compact-queue-bar": "队列栏使用简洁风格",
     "developer": "开发者设置",

--- a/packages/i18n/src/locales/zh_TW.json
+++ b/packages/i18n/src/locales/zh_TW.json
@@ -281,6 +281,7 @@
     "autoradio-craziness": "Autoradio瘋狂度",
     "autoradio-craziness-description": "Autoradio 會自動選擇與crazier中更不相似的歌曲",
     "autoradio-description": "當佇列結束時自動添加相似曲目",
+    "auto-download-favorites": "自動下載最喜歡的曲目",
     "listening-history": "聆聽紀錄",
     "listening-history-description": "儲存你的聆聽記錄，就像Last.fm一樣。\n此聆聽記錄是離線儲存的。",
     "compact-menu-bar": "使用最小化工具列",


### PR DESCRIPTION
## Description  
This PR adds an **auto-download feature** for favorite tracks, allowing users to build their offline library more conveniently. A new **toggle button** is introduced in the **settings menu** to let users choose if they want to automatically download tracks when favoriting them.

## Changes Made  
1. **Added Toggle Button in Settings:**  
   - Users can now enable or disable **auto-download for favorite tracks**.  
   - **Behavior:**
     - Default setting as disable
     - When enabled, all future tracks marked as favorite will be downloaded automatically.
     - Tracks favorited **before enabling the toggle** will **not** be downloaded to avoid duplicate downloads.

2. **Updated Language Files:**  
   - Added `"auto-download-favourites": "Auto download favorite track"` to **all language JSON files**.
   - All translations (except `ZH_CN` and `ZH_TW`) use **English** to avoid translation errors.  
   - **ZH_CN** and **ZH_TW** have been properly translated since I am fluent in these languages. 

## Testing
<img width="556" alt="image" src="https://github.com/user-attachments/assets/02f97e0b-3c21-429b-a4ab-b17af63635c8">

## Screen Recording
<details>
<summary>Video</summary>

[Watch the demo video](https://github.com/user-attachments/assets/b414f7ba-24c9-42cc-b51d-c5f6160f49b4)

</details>

